### PR TITLE
Font Updates & Mac SDK kit upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.pro.user
+*.pro.user.*
+*.autosave
+.DS_Store

--- a/assemblerlistingpane.cpp
+++ b/assemblerlistingpane.cpp
@@ -127,15 +127,6 @@ void AssemblerListingPane::copy()
     ui->textEdit->copy();
 }
 
-void AssemblerListingPane::setFont()
-{
-    bool ok = false;
-    QFont font = QFontDialog::getFont(&ok, QFont(ui->textEdit->font()), this, "Set Assembler Listing Font");
-    if (ok) {
-        ui->textEdit->setFont(font);
-    }
-}
-
 void AssemblerListingPane::setFocus()
 {
     ui->textEdit->setFocus();
@@ -144,6 +135,11 @@ void AssemblerListingPane::setFocus()
 bool AssemblerListingPane::isEmpty()
 {
     return ui->textEdit->toPlainText() == "";
+}
+
+void AssemblerListingPane::onFontChanged(QFont font)
+{
+    ui->textEdit->setFont(font);
 }
 
 void AssemblerListingPane::mouseReleaseEvent(QMouseEvent *)

--- a/assemblerlistingpane.h
+++ b/assemblerlistingpane.h
@@ -56,15 +56,15 @@ public:
 
     void copy();
     // Copies selected text to the clipboard
-
-    void setFont();
-    // Post: the font used by the text edit is set to a font chosen in a font dialog
     
     void setFocus();
     // Post: the text edit has focus
     
     bool isEmpty();
     // Post: returns if the assembler listing is empty
+
+public slots:
+    void onFontChanged(QFont font);
 
 private:
     Ui::AssemblerListingPane *ui;

--- a/helpdialog.cpp
+++ b/helpdialog.cpp
@@ -438,6 +438,12 @@ void HelpDialog::onCurrentItemChanged(QTreeWidgetItem*, QTreeWidgetItem*) {
 }
 
 // Public functions called by main window help menu items:
+void HelpDialog::onFontChanged(QFont font)
+{
+    ui->leftTextEdit->setFont(font);
+    ui->rightCppTextEdit->setFont(font);
+    ui->rightPepTextEdit->setFont(font);
+}
 
 void HelpDialog::machineLanguageClicked()
 {

--- a/helpdialog.h
+++ b/helpdialog.h
@@ -66,6 +66,7 @@ private:
     PepHighlighter *rightPepHighlighter;
 
     enum Row {
+
         eWRITING = 0,
         eDEBUGGING = 1,
         eTRAP = 2,
@@ -121,6 +122,9 @@ private:
         ePROB829 = 42,
         ePROB832 = 43,
     };
+
+public slots:
+    void onFontChanged(QFont font);
 
 private slots:
     void onCurrentItemChanged(QTreeWidgetItem*,QTreeWidgetItem*);

--- a/inputpane.cpp
+++ b/inputpane.cpp
@@ -103,15 +103,6 @@ void InputPane::paste()
     ui->plainTextEdit->paste();
 }
 
-void InputPane::setFont()
-{
-    bool ok = false;
-    QFont font = QFontDialog::getFont(&ok, QFont(ui->plainTextEdit->font()), this, "Set Input Font");
-    if (ok) {
-        ui->plainTextEdit->setFont(font);
-    }
-}
-
 void InputPane::setReadOnly(bool b)
 {
     ui->plainTextEdit->setReadOnly(b);
@@ -135,6 +126,11 @@ void InputPane::tab()
 
         ui->plainTextEdit->insertPlainText(string);
     }
+}
+
+void InputPane::onFontChanged(QFont font)
+{
+    ui->plainTextEdit->setFont(font);
 }
 
 void InputPane::mouseReleaseEvent(QMouseEvent *)

--- a/inputpane.h
+++ b/inputpane.h
@@ -68,14 +68,14 @@ public:
     void paste();
     // Post: selected text in the clipboard is pasted to the text edit
 
-    void setFont();
-    // Post: the font used by the text edit is set to a font chosen in a font dialog
-
     void setReadOnly(bool b);
     // Post: the text edit's read only attribute is set to b
 
     void tab();
     // Post: a tab is inserted in the input pane if it is not read only
+
+public slots:
+    void onFontChanged(QFont font);
 
 private:
     Ui::InputPane *ui;

--- a/listingtracepane.cpp
+++ b/listingtracepane.cpp
@@ -185,21 +185,17 @@ bool ListingTracePane::hasFocus()
     return ui->listingTraceTableWidget->hasFocus() || ui->listingPepOsTraceTableWidget->hasFocus();
 }
 
-void ListingTracePane::setFont()
-{
-    bool ok = false;
-    QFont font = QFontDialog::getFont(&ok, QFont(ui->listingTraceTableWidget->font()), this, "Set Listing Trace Font");
-    if (ok) {
-        ui->listingTraceTableWidget->setFont(font);
-        ui->listingPepOsTraceTableWidget->setFont(font);
-        ui->listingTraceTableWidget->resizeColumnsToContents();
-        ui->listingPepOsTraceTableWidget->resizeColumnsToContents();
-    }
-}
-
 void ListingTracePane::setFocus()
 {
     ui->listingTraceTableWidget->isHidden() ? ui->listingPepOsTraceTableWidget->setFocus() : ui->listingTraceTableWidget->setFocus();
+}
+
+void ListingTracePane::onFontChanged(QFont font)
+{
+    ui->listingTraceTableWidget->setFont(font);
+    ui->listingPepOsTraceTableWidget->setFont(font);
+    ui->listingTraceTableWidget->resizeColumnsToContents();
+    ui->listingPepOsTraceTableWidget->resizeColumnsToContents();
 }
 
 //void ListingTracePane::resizeDocWidth()

--- a/listingtracepane.h
+++ b/listingtracepane.h
@@ -59,15 +59,15 @@ public:
     bool hasFocus();
     // Post: returns if the pane has focus
 
-    void setFont();
-    // Post: the font used by the text edit is set to a font chosen in a font dialog
-
     void setFocus();
     // Post: gives the text edit focus
     
 //    void resizeDocWidth();
     // Post: the document widths of the trace panes are set
     // This is commented, but preserved in case we want to bring back the resizing of the document width to the width of the window.
+
+public slots:
+    void onFontChanged(QFont font);
 
 private:
     Ui::ListingTracePane *ui;

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -68,7 +68,7 @@ protected:
 
 private:
     Ui::MainWindowClass *ui;
-
+    QFont codeFont;
     // Left pane
     SourceCodePane *sourceCodePane;
     ObjectCodePane *objectCodePane;
@@ -150,6 +150,7 @@ private slots:
     void on_actionEdit_Paste_triggered();
     void on_actionEdit_Format_From_Listing_triggered();
     void on_actionEdit_Font_triggered();
+    void on_actionReset_Fonts_to_Defaults_triggered();
     void on_actionEdit_Remove_Error_Messages_triggered();
 
     // Build
@@ -238,7 +239,8 @@ private slots:
     void slotSaveTraceTraps(int);
     void slotSaveTraceLoader(int);
 */
-
+signals:
+    void fontChanged(QFont font);
 };
 
 #endif // MAINWINDOW_H

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -80,7 +80,16 @@
          <string>Code</string>
         </attribute>
         <layout class="QVBoxLayout" name="verticalLayout">
-         <property name="margin">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
           <number>0</number>
          </property>
          <item>
@@ -100,7 +109,16 @@
          <string>Trace</string>
         </attribute>
         <layout class="QVBoxLayout" name="verticalLayout_2">
-         <property name="margin">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
           <number>0</number>
          </property>
          <item>
@@ -169,7 +187,16 @@
           <string>Batch I/O</string>
          </attribute>
          <layout class="QVBoxLayout">
-          <property name="margin">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
            <number>0</number>
           </property>
           <item>
@@ -201,7 +228,16 @@
           <string>Terminal I/O</string>
          </attribute>
          <layout class="QVBoxLayout">
-          <property name="margin">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
            <number>0</number>
           </property>
           <item>
@@ -313,7 +349,7 @@
      <x>0</x>
      <y>0</y>
      <width>1044</width>
-     <height>23</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_Edit">
@@ -334,6 +370,7 @@
     <addaction name="actionEdit_Remove_Error_Messages"/>
     <addaction name="separator"/>
     <addaction name="actionEdit_Font"/>
+    <addaction name="actionReset_Fonts_to_Defaults"/>
    </widget>
    <widget class="QMenu" name="menu_File">
     <property name="toolTip">
@@ -907,6 +944,11 @@
   <action name="actionSystem_Clear_Memory">
    <property name="text">
     <string>Clear Memory</string>
+   </property>
+  </action>
+  <action name="actionReset_Fonts_to_Defaults">
+   <property name="text">
+    <string>Reset Fonts to Defaults</string>
    </property>
   </action>
  </widget>

--- a/memorydumppane.cpp
+++ b/memorydumppane.cpp
@@ -297,19 +297,15 @@ void MemoryDumpPane::copy()
     ui->textEdit->copy();
 }
 
-void MemoryDumpPane::setFont()
-{
-    bool ok = false;
-    QFont font = QFontDialog::getFont(&ok, QFont(ui->textEdit->font()), this, "Set Memory Dump Font");
-    if (ok) {
-        ui->textEdit->setFont(font);
-    }
-}
-
 int MemoryDumpPane::memoryDumpWidth()
 {
     return ui->textEdit->document()->documentLayout()->documentSize().toSize().width() +
             ui->textEdit->verticalScrollBar()->width() + 6;
+}
+
+void MemoryDumpPane::onFontChanged(QFont font)
+{
+    ui->textEdit->setFont(font);
 }
 
 void MemoryDumpPane::highlightByte(int memAddr, QColor foreground, QColor background)

--- a/memorydumppane.h
+++ b/memorydumppane.h
@@ -65,11 +65,11 @@ public:
     void copy();
     // Post: selected text in the text edit is copied to the clipboard
 
-    void setFont();
-    // Post: the font used by the text edit is set to a font chosen in a font dialog
-
     int memoryDumpWidth();
     // Post: the width of the memory dump text edit document is returned
+
+public slots:
+    void onFontChanged(QFont font);
 
 private:
     Ui::MemoryDumpPane *ui;

--- a/memorytracepane.cpp
+++ b/memorytracepane.cpp
@@ -515,19 +515,14 @@ bool MemoryTracePane::hasFocus()
     return ui->graphicsView->hasFocus() || ui->spinBox->hasFocus();
 }
 
-void MemoryTracePane::setFont()
-{
-    // We might just do away with this in this pane.
-    bool ok = false;
-    QFont font = QFontDialog::getFont(&ok, QFont(ui->graphicsView->font()), this, "Set Object Code Font");
-    if (ok) {
-        ui->graphicsView->setFont(font);
-    }
-}
-
 void MemoryTracePane::setFocus()
 {
     ui->graphicsView->setFocus();
+}
+
+void MemoryTracePane::onFontChanged(QFont font)
+{
+    ui->graphicsView->setFont(font);
 }
 
 void MemoryTracePane::addStackFrame(int numCells)

--- a/memorytracepane.h
+++ b/memorytracepane.h
@@ -62,12 +62,12 @@ public:
     bool hasFocus();
     // Post: returns if the pane has focus
 
-    void setFont();
-    // Post: the font used by the text edit is set to a font chosen in a font dialog
-
     void setFocus();
     // Post: the graphics item has focus
-    
+
+public slots:
+    void onFontChanged(QFont font);
+
 private:
     Ui::MemoryTracePane *ui;
 

--- a/objectcodepane.cpp
+++ b/objectcodepane.cpp
@@ -161,18 +161,14 @@ void ObjectCodePane::paste()
     ui->textEdit->paste();
 }
 
-void ObjectCodePane::setFont()
-{
-    bool ok = false;
-    QFont font = QFontDialog::getFont(&ok, QFont(ui->textEdit->font()), this, "Set Object Code Font");
-    if (ok) {
-        ui->textEdit->setFont(font);
-    }
-}
-
 void ObjectCodePane::setReadOnly(bool b)
 {
     ui->textEdit->setReadOnly(b);
+}
+
+void ObjectCodePane::onFontChanged(QFont font)
+{
+    ui->textEdit->setFont(font);
 }
 
 void ObjectCodePane::mouseReleaseEvent(QMouseEvent *)

--- a/objectcodepane.h
+++ b/objectcodepane.h
@@ -90,11 +90,11 @@ public:
     void paste();
     // Post: selected text in the clipboard is pasted to the text edit
 
-    void setFont();
-    // Post: the font used by the text edit is set to a font chosen in a font dialog
-
     void setReadOnly(bool b);
     // Post: the text edit's read only attribute is set to b
+
+public slots:
+    void onFontChanged(QFont font);
 
 private:
     Ui::ObjectCodePane *ui;

--- a/outputpane.cpp
+++ b/outputpane.cpp
@@ -70,13 +70,9 @@ void OutputPane::copy()
     ui->plainTextEdit->copy();
 }
 
-void OutputPane::setFont()
+void OutputPane::onFontChanged(QFont font)
 {
-    bool ok = false;
-    QFont font = QFontDialog::getFont(&ok, QFont(ui->plainTextEdit->font()), this, "Set Output Font");
-    if (ok) {
-        ui->plainTextEdit->setFont(font);
-    }
+   ui->plainTextEdit->setFont(font);
 }
 
 void OutputPane::mouseReleaseEvent(QMouseEvent *)

--- a/outputpane.h
+++ b/outputpane.h
@@ -50,8 +50,8 @@ public:
     void copy();
     // Post: selected text in the text edit is copied to the clipboard
 
-    void setFont();
-    // Post: the font used by the text edit is set to a font chosen in a font dialog
+public slots:
+    void onFontChanged(QFont font);
 
 private:
     Ui::OutputPane *ui;

--- a/pep8.pro
+++ b/pep8.pro
@@ -12,7 +12,7 @@ QT += printsupport
 # Mac icon/plist
 ICON = images/icon.icns
 QMAKE_INFO_PLIST = app.plist
-QMAKE_MAC_SDK = macosx10.11
+QMAKE_MAC_SDK = macosx10.13
 
 # Windows RC file
 RC_FILE = pep8resources.rc

--- a/sourcecodepane.cpp
+++ b/sourcecodepane.cpp
@@ -354,15 +354,6 @@ void SourceCodePane::paste()
     ui->textEdit->paste();
 }
 
-void SourceCodePane::setFont()
-{
-    bool ok = false;
-    QFont font = QFontDialog::getFont(&ok, QFont(ui->textEdit->font()), this, "Set Source Code Font");
-    if (ok) {
-        ui->textEdit->setFont(font);
-    }
-}
-
 void SourceCodePane::setReadOnly(bool b)
 {
     ui->textEdit->setReadOnly(b);
@@ -398,6 +389,11 @@ void SourceCodePane::tab()
 
         ui->textEdit->insertPlainText(string);
     }
+}
+
+void SourceCodePane::onFontChanged(QFont font)
+{
+    ui->textEdit->setFont(font);
 }
 
 void SourceCodePane::mouseReleaseEvent(QMouseEvent *)

--- a/sourcecodepane.h
+++ b/sourcecodepane.h
@@ -132,13 +132,13 @@ public:
     void paste();
     // Post: selected text in the clipboard is pasted to the text edit
 
-    void setFont();
-    // Post: the font used by the text edit is set to a font chosen in a font dialog
-
     void setReadOnly(bool b);
     // Post: the text edit's read only attribute is set to b
 
     void tab();
+
+public slots:
+    void onFontChanged(QFont font);
 
 private:
     Ui::SourceCodePane *ui;

--- a/terminalpane.cpp
+++ b/terminalpane.cpp
@@ -88,13 +88,9 @@ void TerminalPane::copy()
     ui->plainTextEdit->copy();
 }
 
-void TerminalPane::setFont()
+void TerminalPane::onFontChanged(QFont font)
 {
-    bool ok = false;
-    QFont font = QFontDialog::getFont(&ok, QFont(ui->plainTextEdit->font()), this, "Set Terminal Font");
-    if (ok) {
-        ui->plainTextEdit->setFont(font);
-    }
+    ui->plainTextEdit->setFont(font);
 }
 
 void TerminalPane::displayTerminal()

--- a/terminalpane.h
+++ b/terminalpane.h
@@ -54,8 +54,8 @@ public:
     void copy();
     // Post: selected text in the text edit is copied to the clipboard
 
-    void setFont();
-    // Post: the font used by the text edit is set to a font chosen in a font dialog
+public slots:
+    void onFontChanged(QFont font);
 
 private:
     Ui::TerminalPane *ui;


### PR DESCRIPTION
Updated Mac SDK to 10.13
All fonts in all code panes (Source code, listing, input & output panes, help panes) now all share the same font, and this font will be preserved between runs.
Added .gitignore