### PR TITLE
Pep8 compile fixes & installer bug fixes

### DIFF
--- a/Installer/config/control.js
+++ b/Installer/config/control.js
@@ -16,8 +16,8 @@ Controller.prototype.IntroductionPageCallback  = function(){
         widget.findChild("PackageManagerRadioButton").visible = false;
         widget.findChild("PackageManagerRadioButton").enabled = false;
         widget.findChild("PackageManagerRadioButton").text = "";
-        widget.findChild("UninstallerRadioButton").text = "Uninstall XML Tester"
-        widget.findChild("UpdaterRadioButton").text = "Update XML Tester"
+        widget.findChild("UninstallerRadioButton").text = "Uninstall Pep8"
+        widget.findChild("UpdaterRadioButton").text = "Update Pep8"
     }
 
 }

--- a/Installer/packages/pep8/installscript.js
+++ b/Installer/packages/pep8/installscript.js
@@ -10,8 +10,8 @@ Component.prototype.createOperations = function(){
     component.createOperations();
     if(installer.value("os") == "win"){
         component.addOperation("Execute", "@TargetDir@\\vcredist_x64.exe","/install","/passive", "/norestart","/quiet");
-        component.addOperation("CreateShortcut", "@TargetDir@/Pep9CPU.exe", "@StartMenuDir@/Pep9CPU.lnk",
-                    "workingDirectory=@TargetDir@","description=Run Pep9 CPU");
+        component.addOperation("CreateShortcut", "@TargetDir@/Pep8.exe", "@StartMenuDir@/Pep8.lnk",
+                    "workingDirectory=@TargetDir@","description=Run Pep8");
     }
 }
 Component.prototype.installationFinishedPageIsShown = function(){

--- a/Installer/packages/pep8/installscript.js
+++ b/Installer/packages/pep8/installscript.js
@@ -9,7 +9,7 @@ function Component(){
 Component.prototype.createOperations = function(){
     component.createOperations();
     if(installer.value("os") == "win"){
-        component.addOperation("Execute", "@TargetDir@\\vcredist_x64.exe","/install","/passive", "/norestart","/quiet");
+        component.addOperation("Execute", "@TargetDir@\\vc_redist.x64.exe","/install","/passive", "/norestart","/quiet");
         component.addOperation("CreateShortcut", "@TargetDir@/Pep8.exe", "@StartMenuDir@/Pep8.lnk",
                     "workingDirectory=@TargetDir@","description=Run Pep8");
     }

--- a/Installer/packages/pep8/package.xml
+++ b/Installer/packages/pep8/package.xml
@@ -2,7 +2,7 @@
 <Package>
     <DisplayName>Pep8</DisplayName>
     <Description>This tool simulates a CISC CPU, and allows sample programs to be run, tested and visualized.</Description>
-    <Version>8.3</Version>
+    <Version>8.2</Version>
     <ReleaseDate>2018-05-02</ReleaseDate>
     <Licenses>
         <License name="GNU GENERAL PUBLIC LICENSE" file="License.txt" />

--- a/cpupane.cpp
+++ b/cpupane.cpp
@@ -407,7 +407,7 @@ void CpuPane::resumeWithTerminal()
                 emit updateSimulationView();
                 emit executionComplete();
                 isCurrentlySimulating = false;
-#warning "should we return here?"
+#pragma message ("should we return here?")
             }
         }
         if (interruptExecutionFlag) {

--- a/redefinemnemonicsdialog.cpp
+++ b/redefinemnemonicsdialog.cpp
@@ -20,7 +20,7 @@
 */
 #include "redefinemnemonicsdialog.h"
 #include "ui_redefinemnemonicsdialog.h"
-
+#include <QRegExpValidator>
 using namespace Enu;
 
 RedefineMnemonicsDialog::RedefineMnemonicsDialog(QWidget *parent) :


### PR DESCRIPTION
Fixes a bug where the program won't compile when QRegExpValidator is not included correctly.
Fixed a bug with version numbers in the installer.
Fixed a bug where a link in the start menu could not be added.