### PR TITLE
Highlight of all allowed characters in identifiers

### DIFF
--- a/pephighlighter.cpp
+++ b/pephighlighter.cpp
@@ -56,7 +56,7 @@ PepHighlighter::PepHighlighter(QTextDocument *parent)
 
     symbolFormat.setFontWeight(QFont::Bold);
     symbolFormat.setForeground(Qt::darkMagenta);
-    rule.pattern = QRegExp("[A-Za-z0-9_]+(?=:)");
+    rule.pattern = QRegExp("(([A-Z|a-z|_]{1})(\\w*))+(?=:)");
     rule.format = symbolFormat;
     highlightingRules.append(rule);
 


### PR DESCRIPTION
### Summary
This change is purported to make Pep/8 **highlight all allowed characters in identifiers**. Previously, an identifier with an **accented character** would only be highlighted after the accented character, creating a visual distraction when reading the code and making it look incorrect.
Before: aeé**iouy**:
After: **aeéiouy**:
![pep8 changements](https://user-images.githubusercontent.com/7264860/52909125-dee78c80-3250-11e9-9ea8-3daa1748266a.png)
*Image description: Two windows of the Pep/8 editor are shown side-by-side. The one labeled "BEFORE" shows the identifier* `aeéiouy` *(all English vowels in alphabetical order, with an accented 'e' between 'e' and 'i') partially highlighted from 'i' to 'y'. The one labeled "AFTER" shows the same identifier entirely highlighted from 'a' to 'y'.*

### Implementation
The replacement was copy-pasted from line 32 in `asm.cpp`. It is my understanding that this line decides which characters are allowed in identifiers.
`asm.cpp 32: QRegExp Asm::rxIdentifier("^((([A-Z|a-z|_]{1})(\\w*))(:){0,1})");`

### Alternative solutions
The first solution was to simply add the accented characters used in French in the regular expression. The "used in French" clause was quickly discarded as I felt it wasn't ethical to just cover my own language for a feature meant for international usage.  (wide coverage of characters in identifiers)

The second solution was to add all allowed characters in identifiers into the regular expression with ranges such as `À-Ö`. It was quickly discarded when I realized how many there was and that I would need way too many ranges because the valid characters were broken up in many sections of the Unicode table by invalid characters. Tracking all invalid characters, or a mix of both valid and invalid characters, were seen as equally unreasonable solutions.

The third solution was to write `.` before the `+`, effectively highlighting *all* characters before the colon. This solution was discarded in favor of the current one in order to **provide immediate visual feedback** when an **invalid character** is written in an identifier.
Discarded solution: `pephighlighter.cpp 59: rule.pattern = QRegExp(".+(?=:)");`

The fourth, and chosen, solution was to find the function deciding which characters were allowed in identifiers and make an exact match. This is what I believe to have achieved.

### Making a constant instead of copy-pasting
It was pondered whether to make the `(([A-Z|a-z|_]{1})(\\w*))` string some kind of constant accessed by both `asm.cpp` and `pephighlighter.cpp`, but I **decided against** because I am **too unfamiliar with C++** and wouldn't know where would be the best place to put this constant nor what would be the most appropriate implementation.

### Testing
This change was lightly tested at home and apparently worked. "Apparently" means that it seems to work fine _on my machine_, but I don't know if something else broke somewhere else and **I am not confident in my capacities to properly test all edge cases**. This change was also tested with a school assignment, and the program was still working the same as before, and the identifiers with accented characters were completely highlighted.

Also, I used a custom build of Pep/8 which implemented the third solution (highlighting all the characters) a bit more extensively in the last days to do school work. I did not experience any problems in this custom version that I was unable to recreate with the official release version. (8.2)

### Miscellanous
The tests were made by compiling in Qt Creator 4.8.1 with the Qt 5.12.1 MSVC2017 64bit kit. Operating system was Windows 10.

This change was made on Pep/8 because this is what we use in class.

This is my first real pull request and I am a first year student in university.